### PR TITLE
Disable armor sounds volume variation

### DIFF
--- a/infinitysounds/infinitysounds.tp2
+++ b/infinitysounds/infinitysounds.tp2
@@ -741,7 +741,7 @@ COPY ~infinitysounds/copy/wav/gore.wav~ ~override~
 BEGIN @180 DESIGNATED 180 LABEL ~s@-IS-Tweak-Volume-Levels~
 REQUIRE_PREDICATE (GAME_IS ~tob bgee bg2ee eet~) @1
 
-PRINT @3 SILENT
+PRINT @4 SILENT
 
 COPY_EXISTING ~sndchann.2da~ ~override~
   SET_2DA_ENTRY_LATER ~_#_#_#sndchann~  1 0  80 // default
@@ -769,6 +769,15 @@ COPY_EXISTING ~sndchann.2da~ ~override~
   SET_2DA_ENTRIES_NOW ~_#_#_#sndchann~  1
   PRETTY_PRINT_2DA
 BUT_ONLY
+
+// disable hardcoded incremental volume variation on armor sounds
+ACTION_FOR_EACH sound IN arm_01 arm_01a arm_01b arm_01c arm_01d arm_01e arm_01f
+                         arm_02 arm_02a arm_02b arm_02c arm_02d arm_02e arm_02f
+                         arm_03 arm_03a arm_03b arm_03c arm_03d arm_03e arm_03f
+                         arm_04 arm_04a arm_04b arm_04c arm_04d arm_04e arm_04f arm_04g arm_04h BEGIN
+  COPY ~infinitysounds/copy/wfx/default.wfx~ ~override/%sound%.wfx~
+    WRITE_BYTE 0xc 8 // flag volume variation
+END
 
 // Enable Footsteps During Combat
 BEGIN @189 DESIGNATED 189 LABEL ~s@-IS-Footsteps-Combat~


### PR DESCRIPTION
In BG2 there's a hardcoded volume variation on armor walking sounds. Apparently, its effects are incremental, which may often mute these sounds after some time.

This disables the volume variation on armor sounds with WFX override files to match the BG1 behavior (as part of "Tweak Sound Channel Volume Levels.")